### PR TITLE
Updated incoming circuit state on transaction retrieval

### DIFF
--- a/src/PartialCircuitBreaker.php
+++ b/src/PartialCircuitBreaker.php
@@ -107,6 +107,7 @@ abstract class PartialCircuitBreaker implements CircuitBreaker
     {
         if ($this->storage->hasTransaction($service)) {
             $transaction = $this->storage->getTransaction($service);
+            $this->currentPlace = $this->places[$transaction->getState()];
         } else {
             $transaction = SimpleTransaction::createFromPlace(
                 $this->currentPlace,

--- a/src/SimpleCircuitBreaker.php
+++ b/src/SimpleCircuitBreaker.php
@@ -4,7 +4,7 @@ namespace Resiliency;
 
 use Resiliency\Contracts\System;
 use Resiliency\Contracts\Client;
-use Resiliency\Storages\SimpleArray;
+use Resiliency\Contracts\Storage;
 use Resiliency\Exceptions\UnavailableService;
 
 /**
@@ -12,9 +12,9 @@ use Resiliency\Exceptions\UnavailableService;
  */
 final class SimpleCircuitBreaker extends PartialCircuitBreaker
 {
-    public function __construct(System $system, Client $client)
+    public function __construct(System $system, Client $client, Storage $storage)
     {
-        parent::__construct($system, $client, new SimpleArray());
+        parent::__construct($system, $client, $storage);
     }
 
     /**

--- a/src/SimpleCircuitBreakerFactory.php
+++ b/src/SimpleCircuitBreakerFactory.php
@@ -6,6 +6,7 @@ use Resiliency\Contracts\CircuitBreaker;
 use Resiliency\Contracts\Factory;
 use Resiliency\Clients\GuzzleClient;
 use Resiliency\Systems\MainSystem;
+use Resiliency\Storages\SimpleArray;
 
 /**
  * Main implementation of Circuit Breaker Factory
@@ -25,7 +26,8 @@ final class SimpleCircuitBreakerFactory implements Factory
 
         return new SimpleCircuitBreaker(
             $mainSystem,
-            $client
+            $client,
+            new SimpleArray()
         );
     }
 }

--- a/src/Storages/SimpleArray.php
+++ b/src/Storages/SimpleArray.php
@@ -14,7 +14,7 @@ final class SimpleArray implements Storage
     /**
      * @var array the circuit breaker transactions
      */
-    public static $transactions = [];
+    public $transactions = [];
 
     /**
      * {@inheritdoc}
@@ -23,7 +23,7 @@ final class SimpleArray implements Storage
     {
         $key = $this->getKey($service);
 
-        self::$transactions[$key] = $transaction;
+        $this->transactions[$key] = $transaction;
 
         return true;
     }
@@ -36,7 +36,7 @@ final class SimpleArray implements Storage
         $key = $this->getKey($service);
 
         if ($this->hasTransaction($service)) {
-            $transaction = self::$transactions[$key];
+            $transaction = $this->transactions[$key];
 
             if ($transaction instanceof Transaction) {
                 return $transaction;
@@ -53,7 +53,7 @@ final class SimpleArray implements Storage
     {
         $key = $this->getKey($service);
 
-        return array_key_exists($key, self::$transactions);
+        return array_key_exists($key, $this->transactions);
     }
 
     /**
@@ -61,7 +61,7 @@ final class SimpleArray implements Storage
      */
     public function clear(): bool
     {
-        self::$transactions = [];
+        $this->transactions = [];
 
         return true;
     }

--- a/tests/CircuitBreakerWorkflowTest.php
+++ b/tests/CircuitBreakerWorkflowTest.php
@@ -4,6 +4,7 @@ namespace Tests\Resiliency;
 
 use Resiliency\Contracts\CircuitBreaker;
 use Resiliency\Storages\SymfonyCache;
+use Resiliency\Storages\SimpleArray;
 use Resiliency\SymfonyCircuitBreaker;
 use Resiliency\SimpleCircuitBreaker;
 use Symfony\Component\EventDispatcher\Event;
@@ -137,7 +138,7 @@ class CircuitBreakerWorkflowTest extends CircuitBreakerTestCase
     public function getCircuitBreakers(): array
     {
         return [
-             'simple' => [$this->createSimpleCircuitBreaker()],
+            'simple' => [$this->createSimpleCircuitBreaker()],
             'symfony' => [$this->createSymfonyCircuitBreaker()],
         ];
     }
@@ -147,7 +148,11 @@ class CircuitBreakerWorkflowTest extends CircuitBreakerTestCase
      */
     private function createSimpleCircuitBreaker(): SimpleCircuitBreaker
     {
-        return new SimpleCircuitBreaker($this->getSystem(), $this->getTestClient());
+        return new SimpleCircuitBreaker(
+            $this->getSystem(),
+            $this->getTestClient(),
+            new SimpleArray()
+        );
     }
 
     /**

--- a/tests/Storages/SimpleArrayTest.php
+++ b/tests/Storages/SimpleArrayTest.php
@@ -15,7 +15,7 @@ class SimpleArrayTest extends TestCase
     protected function setUp(): void
     {
         $simpleArray = new SimpleArray();
-        $simpleArray::$transactions = [];
+        $simpleArray->transactions = [];
     }
 
     /**
@@ -25,7 +25,7 @@ class SimpleArrayTest extends TestCase
     {
         $simpleArray = new SimpleArray();
 
-        $this->assertCount(0, $simpleArray::$transactions);
+        $this->assertCount(0, $simpleArray->transactions);
         $this->assertInstanceOf(SimpleArray::class, $simpleArray);
     }
 
@@ -42,7 +42,7 @@ class SimpleArrayTest extends TestCase
             $this->createMock(Transaction::class)
         );
         $this->assertTrue($operation);
-        $this->assertCount(1, $simpleArray::$transactions);
+        $this->assertCount(1, $simpleArray->transactions);
     }
 
     /**
@@ -107,7 +107,7 @@ class SimpleArrayTest extends TestCase
 
         // We have stored 2 transactions
         $simpleArray->clear();
-        $transactions = $simpleArray::$transactions;
+        $transactions = $simpleArray->transactions;
         $this->assertEmpty($transactions);
     }
 }


### PR DESCRIPTION
Between 2 requests, the circuit breaker is not retrieved in the right place.

Let's say, it was open and then we call again the service in a new request (so the circuit is retrieved from the storage), we should put the circuit breaker at the same place/state.

