### PR TITLE
Introduced manual controls

### DIFF
--- a/src/Contracts/CircuitBreaker.php
+++ b/src/Contracts/CircuitBreaker.php
@@ -39,4 +39,28 @@ interface CircuitBreaker
      * @return bool checks if the circuit breaker is closed
      */
     public function isClosed(): bool;
+
+    /**
+     * @return bool checks if the circuit breaker is isolated
+     */
+    public function isIsolated(): bool;
+
+    /**
+     * Manually open (and hold open) the Circuit Breaker
+     * This can be used for example to take it offline for maintenance.
+     *
+     * @param string $service the service to call
+     *
+     * @return self
+     */
+    public function isolate(string $service): self;
+
+    /**
+     * Reset the breaker to closed state to start accepting actions again.
+     *
+     * @param string $service the service to call
+     *
+     * @return self
+     */
+    public function reset(string $service): self;
 }

--- a/src/Places/ClosedPlace.php
+++ b/src/Places/ClosedPlace.php
@@ -7,8 +7,8 @@ use Resiliency\States;
 /**
  * The circuit initially starts closed. When the circuit is closed:
  *
- * The circuit-breaker executes actions placed through it, measuring the faults and successes of those actions.
- * If the faults exceed a certain threshold, the circuit will break (open).
+ * The circuit-breaker executes actions placed through it, measuring the failures and successes of those actions.
+ * If the failures exceed a certain threshold, the circuit will break (open).
  */
 final class ClosedPlace extends AbstractPlace
 {

--- a/src/Places/ClosedPlace.php
+++ b/src/Places/ClosedPlace.php
@@ -4,6 +4,12 @@ namespace Resiliency\Places;
 
 use Resiliency\States;
 
+/**
+ * The circuit initially starts closed. When the circuit is closed:
+ *
+ * The circuit-breaker executes actions placed through it, measuring the faults and successes of those actions.
+ * If the faults exceed a certain threshold, the circuit will break (open).
+ */
 final class ClosedPlace extends AbstractPlace
 {
     /**

--- a/src/Places/HalfOpenPlace.php
+++ b/src/Places/HalfOpenPlace.php
@@ -4,6 +4,16 @@ namespace Resiliency\Places;
 
 use Resiliency\States;
 
+/**
+ * When the circuit is half-open:
+ *
+ * the next action will be treated as a trial, to determine the circuit's health.
+ *
+ * If this call throws a handled exception, that exception is rethrown,
+ * and the circuit transitions immediately back to open, and remains open again for the configured timespan.
+ *
+ * If the call throws no exception, the circuit transitions back to closed.
+ */
 final class HalfOpenPlace extends AbstractPlace
 {
     /**

--- a/src/Places/IsolatedPlace.php
+++ b/src/Places/IsolatedPlace.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Resiliency\Places;
+
+use Resiliency\States;
+
+/**
+ * This state is manually triggered to ensure the Circuit Breaker
+ * remains open until we reset it.
+ */
+class IsolatedPlace extends AbstractPlace
+{
+    public function __construct()
+    {
+        parent::__construct(0, 0.0, 0.0);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getState(): string
+    {
+        return States::ISOLATED_STATE;
+    }
+}

--- a/src/Places/OpenPlace.php
+++ b/src/Places/OpenPlace.php
@@ -4,6 +4,10 @@ namespace Resiliency\Places;
 
 use Resiliency\States;
 
+/**
+ * While the circuit is in an open state: every call to the service
+ * won't be executed and the fallback callback is executed.
+ */
 final class OpenPlace extends AbstractPlace
 {
     /**

--- a/src/States.php
+++ b/src/States.php
@@ -27,4 +27,10 @@ final class States
      * to evaluate is done and not the alternative call.
      */
     const CLOSED_STATE = 'CLOSED';
+
+    /**
+     * Once isolated, the circuit breaker stays in OPEN state and
+     * won't accepts any requests, even when the threshold is reached.
+     */
+    const ISOLATED_STATE = 'ISOLATED';
 }

--- a/src/States.php
+++ b/src/States.php
@@ -30,7 +30,7 @@ final class States
 
     /**
      * Once isolated, the circuit breaker stays in OPEN state and
-     * won't accepts any requests, even when the threshold is reached.
+     * won't accept any requests, even when the threshold is reached.
      */
     const ISOLATED_STATE = 'ISOLATED';
 }

--- a/src/Systems/MainSystem.php
+++ b/src/Systems/MainSystem.php
@@ -2,6 +2,7 @@
 
 namespace Resiliency\Systems;
 
+use Resiliency\Places\IsolatedPlace;
 use Resiliency\States;
 use Resiliency\Contracts\Place;
 use Resiliency\Contracts\System;
@@ -39,11 +40,13 @@ final class MainSystem implements System
         $closedPlace = new ClosedPlace($failures, $timeout);
         $halfOpenPlace = new HalfOpenPlace($strippedTimeout);
         $openPlace = new OpenPlace($threshold);
+        $isolatedPlace = new IsolatedPlace();
 
         $this->places = [
             $closedPlace->getState() => $closedPlace,
             $halfOpenPlace->getState() => $halfOpenPlace,
             $openPlace->getState() => $openPlace,
+            $isolatedPlace->getState() => $isolatedPlace,
         ];
     }
 

--- a/src/Transitions.php
+++ b/src/Transitions.php
@@ -40,4 +40,14 @@ final class Transitions
      * Happened on each try to call the service.
      */
     const TRIAL_TRANSITION = 'TRIAL';
+
+    /**
+     * Happened when the Circuit Breaker is isolated.
+     */
+    const ISOLATING_TRANSITION = 'ISOLATING';
+
+    /**
+     *  Happened when the Circuit Breaker is reset.
+     */
+    const RESETTING_TRANSITION = 'RESETTING';
 }

--- a/tests/CircuitBreakerWorkflowTest.php
+++ b/tests/CircuitBreakerWorkflowTest.php
@@ -121,6 +121,10 @@ class CircuitBreakerWorkflowTest extends CircuitBreakerTestCase
             $this->assertSame('{}', $response);
             $this->assertTrue($circuitBreaker->isIsolated());
         }
+
+        $circuitBreaker->reset('https://httpbin.org/get/foo');
+
+        $this->assertTrue($circuitBreaker->isClosed());
     }
 
     /**

--- a/tests/CircuitBreakerWorkflowTest.php
+++ b/tests/CircuitBreakerWorkflowTest.php
@@ -101,6 +101,29 @@ class CircuitBreakerWorkflowTest extends CircuitBreakerTestCase
     }
 
     /**
+     * The Circuit Breaker can be isolated, once its done it remains
+     * Open and so on only fallback responses will be sent.
+     *
+     * @dataProvider getCircuitBreakers
+     */
+    public function testOnceCircuitBreakerIsIsolatedNoTrialsAreDone(CircuitBreaker $circuitBreaker): void
+    {
+        $circuitBreaker->isolate('https://httpbin.org/get/foo');
+
+        $response = $circuitBreaker->call('https://httpbin.org/get/foo', $this->createFallbackResponse());
+        $this->assertSame('{}', $response);
+        $this->assertTrue($circuitBreaker->isIsolated());
+
+        // Let's do 10 calls!
+
+        for ($i = 0; $i < 10; ++$i) {
+            $circuitBreaker->call('https://httpbin.org/get/foo', $this->createFallbackResponse());
+            $this->assertSame('{}', $response);
+            $this->assertTrue($circuitBreaker->isIsolated());
+        }
+    }
+
+    /**
      * Return the list of supported circuit breakers
      *
      * @return array

--- a/tests/System/MainSystemTest.php
+++ b/tests/System/MainSystemTest.php
@@ -36,7 +36,7 @@ class MainSystemTest extends TestCase
         $places = $mainSystem->getPlaces();
 
         $this->assertIsArray($places);
-        $this->assertCount(3, $places);
+        $this->assertCount(4, $places);
 
         foreach ($places as $place) {
             $this->assertInstanceOf(Place::class, $place);


### PR DESCRIPTION
Introduced `isolate` and `reset` functions:

* `isolate` a circuit breaker will make it rely on the fallback response until we reset it, it could be useful when we put an application on maintenance state;
* `reset` put the circuit breaker on `CLOSED` state again, *without* remove any previous transaction: this means you won't trigger "INITIATING" again.

About that, what would be the more logic behavior? /c  @jolelievre