### PR TITLE
On clear and increment return the number of failures

### DIFF
--- a/src/Contracts/Transaction.php
+++ b/src/Contracts/Transaction.php
@@ -34,14 +34,14 @@ interface Transaction
     /**
      * Every time the service call fails, increment the number of failures.
      *
-     * @return bool
+     * @return int the number of failures (inclusive)
      */
-    public function incrementFailures(): bool;
+    public function incrementFailures(): int;
 
     /**
      * If the service is up again, reset the number of failures to 0.
      *
-     * @return bool
+     * @return int the number of failures
      */
-    public function clearFailures(): bool;
+    public function clearFailures(): int;
 }

--- a/src/Transactions/SimpleTransaction.php
+++ b/src/Transactions/SimpleTransaction.php
@@ -87,21 +87,20 @@ final class SimpleTransaction implements Transaction
     /**
      * {@inheritdoc}
      */
-    public function incrementFailures(): bool
+    public function incrementFailures(): int
     {
-        ++$this->failures;
-
-        return true;
+        return ++$this->failures;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function clearFailures(): bool
+    public function clearFailures(): int
     {
+        $res = $this->failures;
         $this->failures = 0;
 
-        return true;
+        return $res;
     }
 
     /**

--- a/tests/Transactions/SimpleTransactionTest.php
+++ b/tests/Transactions/SimpleTransactionTest.php
@@ -76,9 +76,22 @@ class SimpleTransactionTest extends CircuitBreakerTestCase
     public function testIncrementFailures()
     {
         $simpleTransaction = $this->createSimpleTransaction();
-        $simpleTransaction->incrementFailures();
+        self::assertSame(1, $simpleTransaction->incrementFailures());
 
         self::assertSame(1, $simpleTransaction->getFailures());
+    }
+
+    /**
+     * @depends testCreation
+     * @depends testGetFailures
+     */
+    public function testClearFailures()
+    {
+        $simpleTransaction = $this->createSimpleTransaction();
+        self::assertSame(1, $simpleTransaction->incrementFailures());
+        self::assertSame(1, $simpleTransaction->getFailures());
+        self::assertSame(1, $simpleTransaction->clearFailures());
+        self::assertSame(0, $simpleTransaction->getFailures());
     }
 
     /**


### PR DESCRIPTION
The main goal is to be able to get the number of failures on update. This will be useful for log or stats (coming next)