### PR TITLE
Added support of PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ notifications:
 php:
   - 7.2
   - 7.3
+  - 7.4
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Resiliency should be able to work with the latest version of PHP 7