### PR TITLE
[FEAT] Be able to get information about the exception thrown in case of failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Resiliency, an implementation for resilient and modern PHP applications
 
-[![codecov](https://codecov.io/gh/loveOSS/resiliency/branch/master/graph/badge.svg)](https://codecov.io/gh/loveOSS/resiliency) [![PHPStan](https://img.shields.io/badge/PHPStan-Level%207-brightgreen.svg?style=flat&logo=php)](https://shields.io/#/) [![Psalm](https://img.shields.io/badge/Psalm-Level%20Max-brightgreen.svg?style=flat&logo=php)](https://shields.io/#/) [![Build Status](https://travis-ci.com/loveOSS/resiliency.svg?branch=master)](https://travis-ci.com/loveOSS/resiliency) 
+[![codecov](https://codecov.io/gh/loveOSS/resiliency/branch/master/graph/badge.svg)](https://codecov.io/gh/loveOSS/resiliency) [![PHPStan](https://img.shields.io/badge/PHPStan-Level%20max-brightgreen.svg?style=flat&logo=php)](https://shields.io/#/) [![Psalm](https://img.shields.io/badge/Psalm-Level%20Max-brightgreen.svg?style=flat&logo=php)](https://shields.io/#/) [![Build Status](https://travis-ci.com/loveOSS/resiliency.svg?branch=master)](https://travis-ci.com/loveOSS/resiliency) 
 
 ## Main principles
 

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",
         "phpunit/phpunit": "^8.0",
-        "symfony/cache": "~4.4|~5.3",
-        "symfony/http-client": "^4.4|~5.3",
+        "symfony/cache": "~4.4|~5.4|~6.0",
+        "symfony/http-client": "^4.4|~5.4|~6.0",
         "vimeo/psalm": "^4.3"
     },
     "suggest": {
@@ -49,7 +49,7 @@
     },
     "scripts": {
         "cs-fix": "@php ./vendor/bin/php-cs-fixer fix",
-        "phpqa": "@php ./vendor/bin/phpqa --report --tools phpcs:0,phpmd:0,phpmetrics,phploc,pdepend,security-checker:0,parallel-lint:0 --ignoredDirs tests,vendor",
+        "phpqa": "@php ./vendor/bin/phpqa --report --tools phpcs:0,phpmetrics,phploc,pdepend,security-checker:0,parallel-lint:0 --ignoredDirs tests,vendor",
         "phpstan": "@php ./vendor/bin/phpstan analyse src --level max -c extension.neon",
         "psalm": "@php ./vendor/bin/psalm --threads=8 --diff",
         "test": "@php ./vendor/bin/phpunit"

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -3,7 +3,6 @@
     name="Psalm configuration for the Resiliency library"
     totallyTyped="true"
     strictBinaryOperands="true"
-    allowPhpStormGenerics="true"
     allowStringToStandInForClass="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/src/Contracts/ThrowableEvent.php
+++ b/src/Contracts/ThrowableEvent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Resiliency\Contracts;
+
+/**
+ * Specific event in case of failure.
+ */
+interface ThrowableEvent extends Event
+{
+    /**
+     * @return Exception the Exception
+     */
+    public function getException(): Exception;
+}

--- a/src/Events/Failed.php
+++ b/src/Events/Failed.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Resiliency\Events;
+
+use Resiliency\Contracts\CircuitBreaker;
+use Resiliency\Contracts\Exception;
+use Resiliency\Contracts\Service;
+use Resiliency\Contracts\ThrowableEvent;
+
+final class Failed extends TransitionEvent implements ThrowableEvent
+{
+    /**
+     * We need to understand why a call have failed.
+     *
+     * @var Exception the exception
+     */
+    private $exception;
+
+    /**
+     * @param CircuitBreaker $circuitBreaker the circuit breaker
+     * @param Service $service the Service
+     */
+    public function __construct(CircuitBreaker $circuitBreaker, Service $service, Exception $exception)
+    {
+        $this->exception = $exception;
+
+        parent::__construct($circuitBreaker, $service);
+    }
+
+    public function getException(): Exception
+    {
+        return $this->exception;
+    }
+}

--- a/src/Places/Closed.php
+++ b/src/Places/Closed.php
@@ -4,6 +4,7 @@ namespace Resiliency\Places;
 
 use Resiliency\Contracts\Client;
 use Resiliency\Contracts\Transaction;
+use Resiliency\Events\Failed;
 use Resiliency\Events\Tried;
 use Resiliency\Exceptions\UnavailableService;
 use Resiliency\States;
@@ -55,6 +56,7 @@ final class Closed extends PlaceHelper
 
             return $response;
         } catch (UnavailableService $exception) {
+            $this->dispatch(new Failed($this->circuitBreaker, $service, $exception));
             $transaction->incrementFailures();
             $storage->saveTransaction($service->getUri(), $transaction);
 

--- a/src/Systems/MainSystem.php
+++ b/src/Systems/MainSystem.php
@@ -99,7 +99,7 @@ final class MainSystem implements System
     {
         // @doc https://www.php.net/manual/info.configuration.php the timeout is in seconds
         $maxExecutionTime = ini_get('max_execution_time');
-        
+
         $timeoutInSeconds = (int) ($timeout / 1000);
 
         return (0 === (int) $maxExecutionTime) || ($maxExecutionTime >= $timeoutInSeconds);

--- a/tests/SymfonyCircuitBreakerEventsTest.php
+++ b/tests/SymfonyCircuitBreakerEventsTest.php
@@ -7,6 +7,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use ReflectionClass;
 use ReflectionException;
 use Resiliency\Contracts\CircuitBreaker;
+use Resiliency\Events\Failed;
 use Resiliency\Events\Initiated;
 use Resiliency\Events\Isolated;
 use Resiliency\Events\Opened;
@@ -54,12 +55,14 @@ class SymfonyCircuitBreakerEventsTest extends CircuitBreakerTestCase
          * then the conditions are met to open the circuit breaker
          */
         $invocations = self::invocations($this->spy);
-        self::assertCount(4, $invocations);
+        self::assertCount(6, $invocations);
 
         self::assertInstanceOf(Initiated::class, $invocations[0]->getParameters()[0]);
         self::assertInstanceOf(Tried::class, $invocations[1]->getParameters()[0]);
-        self::assertInstanceOf(Tried::class, $invocations[2]->getParameters()[0]);
-        self::assertInstanceOf(Opened::class, $invocations[3]->getParameters()[0]);
+        self::assertInstanceOf(Failed::class, $invocations[2]->getParameters()[0]);
+        self::assertInstanceOf(Tried::class, $invocations[3]->getParameters()[0]);
+        self::assertInstanceOf(Failed::class, $invocations[4]->getParameters()[0]);
+        self::assertInstanceOf(Opened::class, $invocations[5]->getParameters()[0]);
     }
 
     public function testCircuitBreakerEventsOnIsolationAndResetActions(): void
@@ -79,8 +82,8 @@ class SymfonyCircuitBreakerEventsTest extends CircuitBreakerTestCase
          * the related event has been dispatched
          */
         $invocations = self::invocations($this->spy);
-        self::assertCount(5, $invocations);
-        self::assertInstanceOf(Isolated::class, $invocations[4]->getParameters()[0]);
+        self::assertCount(7, $invocations);
+        self::assertInstanceOf(Isolated::class, $invocations[6]->getParameters()[0]);
 
         /*
          * And now we reset the circuit breaker!
@@ -88,8 +91,8 @@ class SymfonyCircuitBreakerEventsTest extends CircuitBreakerTestCase
          */
         $circuitBreaker->reset($service);
         $invocations = self::invocations($this->spy);
-        self::assertCount(6, $invocations);
-        self::assertInstanceOf(Reseted::class, $invocations[5]->getParameters()[0]);
+        self::assertCount(8, $invocations);
+        self::assertInstanceOf(Reseted::class, $invocations[7]->getParameters()[0]);
     }
 
     private function createCircuitBreaker(): CircuitBreaker


### PR DESCRIPTION
As point in https://github.com/loveOSS/resiliency/issues/61, we are not able to know which exception is responsible of a failure and so on we are not able to open/close manually our circuit breaker according to the exception.

As the current architecture doesn't allows to setup the related exception of a circuit breaker, the only chance we get is to add a new event and allow developer to manually setup new conditions of open/close decision.

```php
// ThrowableEvent
function listener(Failed $event) {
    $exception = $event->getException();

   if ($exception->getException() instanceof HttpNotFoundOrWhatever) {
       $uri = $event->getService()->getURI();
       $circuitBreaker = $event->getCircuitBreaker();
       $circuitBreaker ->isolate($uri);
       // OR
       $circuitBreaker ->reset($uri);
   }
};
```

This could be improved but I don't see how without introducing a big breaking change, what I don't want as I'm not involved in PHP projects anymore.

